### PR TITLE
fix: remove unused error variables in catch blocks

### DIFF
--- a/src/reports/markdown-report.js
+++ b/src/reports/markdown-report.js
@@ -272,7 +272,7 @@ export class MarkdownReportGenerator {
       if (decodedPath) {
         try {
           decodedPath = decodeURIComponent(decodedPath);
-        } catch (error) {
+        } catch {
           decodedPath = normalizedPath;
         }
       }
@@ -282,7 +282,7 @@ export class MarkdownReportGenerator {
       if (segmentsToShow.length > 0) {
         return segmentsToShow.join('/');
       }
-    } catch (error) {
+    } catch {
       // noop
     }
     return 'Source';


### PR DESCRIPTION
Fixes ESLint errors by removing unused error parameters from catch blocks in markdown-report.js.

## Changes
- Removed unused `error` parameter from `decodeURIComponent` catch block
- Removed unused `error` parameter from URL parsing catch block

This resolves the linting errors:
```
E:\appscan-client\src\reports\markdown-report.js
  275:18  error  'error' is defined but never used  no-unused-vars
  285:14  error  'error' is defined but never used  no-unused-vars
```