### PR TITLE
Feat: Pipeline variable search + streaming JSON for secrets list (rebased)

### DIFF
--- a/lab/azdo-16-search-pipeline-variables.js
+++ b/lab/azdo-16-search-pipeline-variables.js
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+/**
+ * azdo-16-search-pipeline-variables.js
+ *
+ * Purpose: Search for pipeline variables across all projects in the organization.
+ * Searches both pipeline-level variables and variable groups.
+ *
+ * Usage:
+ *   node lab/azdo-16-search-pipeline-variables.js [options]
+ *
+ * Options:
+ *   --name <pattern>     Search by variable name (case-insensitive partial match)
+ *   --value <pattern>    Search by variable value (only non-secret variables)
+ *   --project <name>     Limit search to a specific project
+ *   --include-secrets    Include secret variables in results (value will be hidden)
+ *   --json               Output results as JSON
+ *
+ * Examples:
+ *   node lab/azdo-16-search-pipeline-variables.js --name username
+ *   node lab/azdo-16-search-pipeline-variables.js --value "myuser@domain.com"
+ *   node lab/azdo-16-search-pipeline-variables.js --name password --include-secrets
+ *   node lab/azdo-16-search-pipeline-variables.js --project MyProject --name api
+ *
+ * Note: Secret variable VALUES cannot be retrieved via the API for security reasons.
+ *       You can only search by name for secrets, and the value will show as "[SECRET]".
+ */
+
+import dotenv from 'dotenv';
+import fs from 'fs';
+import { getEnvPath } from '../src/utils/config-paths.js';
+
+// Load environment variables from the correct path (same as TUI)
+const envPath = getEnvPath();
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+} else {
+  dotenv.config();
+}
+
+// Initialize proxy/TLS configuration (must be after dotenv)
+await import('../src/utils/bootstrap-proxy.js');
+
+import chalk from 'chalk';
+import { AzdoService } from '../src/tui/shared/services/azdo.js';
+
+/**
+ * Parse command line arguments
+ * @returns {Object} Parsed arguments
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const result = {
+    searchName: undefined,
+    searchValue: undefined,
+    project: undefined,
+    includeSecrets: false,
+    useRegex: false,
+    json: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--name':
+        result.searchName = args[++i];
+        break;
+      case '--value':
+        result.searchValue = args[++i];
+        break;
+      case '--project':
+        result.project = args[++i];
+        break;
+      case '--include-secrets':
+        result.includeSecrets = true;
+        break;
+      case '--regex':
+        result.useRegex = true;
+        break;
+      case '--json':
+        result.json = true;
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(0);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Print usage information
+ */
+function printUsage() {
+  console.log(`
+${chalk.bold('Azure DevOps Pipeline Variables Scanner')}
+
+${chalk.yellow('Usage:')}
+  node lab/azdo-16-search-pipeline-variables.js [options]
+
+${chalk.yellow('Options:')}
+  --name <pattern>     Search by variable name (case-insensitive partial match)
+  --value <pattern>    Search by variable value (only non-secret variables)
+  --project <name>     Limit search to a specific project
+  --include-secrets    Include secret variables in results (value will be hidden)
+  --regex              Treat --name and --value as regex patterns
+  --json               Output results as JSON
+  --help, -h           Show this help message
+
+${chalk.yellow('Examples:')}
+  node lab/azdo-16-search-pipeline-variables.js --name username
+  node lab/azdo-16-search-pipeline-variables.js --value "myuser@domain.com"
+  node lab/azdo-16-search-pipeline-variables.js --name password --include-secrets
+  node lab/azdo-16-search-pipeline-variables.js --project MyProject --name api
+  node lab/azdo-16-search-pipeline-variables.js --name "^API_.*KEY$" --regex
+
+${chalk.yellow('Note:')}
+  Secret variable VALUES cannot be retrieved via the API for security reasons.
+  You can only search by name for secrets, and the value will show as "[SECRET]".
+`);
+}
+
+/**
+ * Format a variable match for display
+ * @param {Object} match - Variable match object
+ * @returns {string} Formatted string
+ */
+function formatMatch(match) {
+  const lines = [];
+  lines.push(chalk.cyan.bold(`Variable: ${match.variableName}`));
+  lines.push(chalk.gray('  Project:        ') + chalk.white(match.projectName));
+
+  if (match.source === 'pipeline') {
+    lines.push(
+      chalk.gray('  Pipeline:       ') +
+        chalk.white(`${match.pipelinePath}${match.pipelineName}`) +
+        chalk.dim(` (ID: ${match.pipelineId})`)
+    );
+  } else if (match.source === 'variableGroup') {
+    if (match.pipelineName) {
+      lines.push(
+        chalk.gray('  Pipeline:       ') +
+          chalk.white(`${match.pipelinePath}${match.pipelineName}`) +
+          chalk.dim(` (ID: ${match.pipelineId})`)
+      );
+    }
+    lines.push(
+      chalk.gray('  Variable Group: ') +
+        chalk.white(match.variableGroupName) +
+        chalk.dim(` (ID: ${match.variableGroupId})`)
+    );
+  }
+
+  if (match.isSecret) {
+    lines.push(chalk.gray('  Value:          ') + chalk.red('[SECRET]'));
+  } else {
+    lines.push(
+      chalk.gray('  Value:          ') +
+        chalk.green(match.variableValue || '(empty)')
+    );
+  }
+
+  lines.push(chalk.gray('  Source:         ') + chalk.dim(match.source));
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const args = parseArgs();
+
+  if (!args.searchName && !args.searchValue) {
+    console.error(
+      chalk.red(
+        'Error: You must specify at least --name or --value to search for.'
+      )
+    );
+    console.log(chalk.gray('Use --help for usage information.'));
+    process.exit(1);
+  }
+
+  if (args.searchValue && args.includeSecrets) {
+    console.log(
+      chalk.yellow(
+        'Note: Searching by value only works for non-secret variables. Secret values are not accessible via the API.'
+      )
+    );
+  }
+
+  try {
+    if (!args.json) {
+      console.log(chalk.cyan.bold('Azure DevOps Pipeline Variables Scanner'));
+      console.log(chalk.gray('Using TUI AzdoService\n'));
+    }
+
+    // Initialize the AzdoService
+    const azdoService = new AzdoService();
+
+    // Determine which projects to scan
+    let projects;
+    if (args.project) {
+      // Search specific project
+      if (!args.json) {
+        console.log(chalk.yellow(`Searching in project: ${args.project}`));
+      }
+      projects = [{ name: args.project, id: args.project }];
+    } else {
+      // Get all projects
+      if (!args.json) {
+        console.log(chalk.yellow('Fetching projects...'));
+      }
+      projects = await azdoService.listProjects();
+      if (!args.json) {
+        console.log(chalk.green(`Found ${projects.length} projects\n`));
+      }
+    }
+
+    const allResults = [];
+    let totalPipelines = 0;
+    let totalVariableGroups = 0;
+
+    // Progress tracking
+    const totalProjects = projects.length;
+    let processedProjects = 0;
+
+    for (const project of projects) {
+      processedProjects++;
+
+      if (!args.json) {
+        const percentage = Math.round(
+          (processedProjects / totalProjects) * 100
+        );
+        const barLength = 40;
+        const filledLength = Math.round((percentage / 100) * barLength);
+        const bar =
+          chalk.cyan('█'.repeat(filledLength)) +
+          chalk.gray('░'.repeat(barLength - filledLength));
+
+        process.stdout.write(
+          `\r[${bar}] ${chalk.bold(percentage + '%')} | ${processedProjects}/${totalProjects} projects | ${chalk.yellow(allResults.length)} matches`
+        );
+      }
+
+      try {
+        // Search pipeline variables
+        const pipelineResults = await azdoService.searchPipelineVariables(
+          project.name,
+          {
+            searchName: args.searchName,
+            searchValue: args.searchValue,
+            includeSecrets: args.includeSecrets,
+            useRegex: args.useRegex,
+          }
+        );
+
+        // Count unique pipelines
+        const pipelineIds = new Set(pipelineResults.map((r) => r.pipelineId));
+        totalPipelines += pipelineIds.size;
+
+        allResults.push(...pipelineResults);
+
+        // Search variable groups (standalone, not linked to pipelines)
+        const groupResults = await azdoService.searchVariableGroups(
+          project.name,
+          {
+            searchName: args.searchName,
+            searchValue: args.searchValue,
+            includeSecrets: args.includeSecrets,
+            useRegex: args.useRegex,
+          }
+        );
+
+        // Count unique variable groups
+        const groupIds = new Set(groupResults.map((r) => r.variableGroupId));
+        totalVariableGroups += groupIds.size;
+
+        // Add group results that aren't already included via pipeline search
+        for (const groupResult of groupResults) {
+          const alreadyIncluded = allResults.some(
+            (r) =>
+              r.variableGroupId === groupResult.variableGroupId &&
+              r.variableName === groupResult.variableName
+          );
+          if (!alreadyIncluded) {
+            allResults.push(groupResult);
+          }
+        }
+      } catch (error) {
+        // Skip projects with no access or errors
+        if (!args.json && error.statusCode !== 404) {
+          // Silently skip - common for projects without pipelines
+        }
+      }
+    }
+
+    if (!args.json) {
+      // Clear progress line
+      console.log('\n');
+    }
+
+    // Output results
+    if (args.json) {
+      console.log(
+        JSON.stringify(
+          {
+            searchCriteria: {
+              name: args.searchName,
+              value: args.searchValue,
+              includeSecrets: args.includeSecrets,
+              useRegex: args.useRegex,
+              project: args.project,
+            },
+            summary: {
+              totalMatches: allResults.length,
+              projectsScanned: projects.length,
+              pipelinesScanned: totalPipelines,
+              variableGroupsScanned: totalVariableGroups,
+            },
+            results: allResults,
+          },
+          null,
+          2
+        )
+      );
+    } else {
+      if (allResults.length === 0) {
+        console.log(chalk.gray('No matching variables found.'));
+      } else {
+        console.log(
+          chalk.green.bold(`Found ${allResults.length} matching variable(s):\n`)
+        );
+        console.log(chalk.gray('─'.repeat(80)));
+
+        for (const match of allResults) {
+          console.log(formatMatch(match));
+          console.log(chalk.gray('─'.repeat(80)));
+        }
+
+        // Summary
+        console.log(chalk.bold('\nSummary:'));
+        console.log(
+          chalk.gray('  Projects scanned:       ') +
+            chalk.white(projects.length)
+        );
+        console.log(
+          chalk.gray('  Pipelines scanned:      ') + chalk.white(totalPipelines)
+        );
+        console.log(
+          chalk.gray('  Variable groups scanned:') +
+            chalk.white(totalVariableGroups)
+        );
+        console.log(
+          chalk.gray('  Total matches:          ') +
+            chalk.green.bold(allResults.length)
+        );
+
+        // Group by source
+        const bySource = allResults.reduce((acc, r) => {
+          acc[r.source] = (acc[r.source] || 0) + 1;
+          return acc;
+        }, {});
+        console.log(
+          chalk.gray('  From pipelines:         ') +
+            chalk.white(bySource.pipeline || 0)
+        );
+        console.log(
+          chalk.gray('  From variable groups:   ') +
+            chalk.white(bySource.variableGroup || 0)
+        );
+
+        // Secret vs non-secret
+        const secretCount = allResults.filter((r) => r.isSecret).length;
+        const nonSecretCount = allResults.length - secretCount;
+        console.log(
+          chalk.gray('  Secret variables:       ') + chalk.yellow(secretCount)
+        );
+        console.log(
+          chalk.gray('  Non-secret variables:   ') + chalk.white(nonSecretCount)
+        );
+      }
+    }
+
+    process.exit(0);
+  } catch (err) {
+    if (args.json) {
+      console.log(JSON.stringify({ error: err.message }, null, 2));
+    } else {
+      console.error(chalk.red.bold('\nError: ') + chalk.red(err.message));
+      if (err.stack) {
+        console.error(chalk.gray('\nStack trace:'));
+        console.error(chalk.gray(err.stack));
+      }
+    }
+    process.exit(1);
+  }
+}
+
+main();

--- a/lab/secrets-list-and-search-code.ps1
+++ b/lab/secrets-list-and-search-code.ps1
@@ -1,0 +1,42 @@
+﻿pushd "C:\ITStore\phave\Dev\appscan-client"
+
+if(-not $secretList) {
+  $secretList = node dist/index.js list-azdo-secrets --include-fixed --include-dismissed --json |
+    ConvertFrom-Json
+}
+$secretList.validationFingerprints.validationFingerprintJson |
+      ConvertFrom-Json |
+      group-object secret |
+      Sort-Object count -Descending |<#
+      select -first 10 |
+      #> Select Count,Name |% {
+        $alertSecret = $_.Name
+        $alertCount = $_.Count
+        write-warning "($alertCount) $alertSecret"
+
+        $SearchResult = node dist/index.js azdo-search $alertSecret --json 2>$null |
+            ConvertFrom-Json
+        $SearchResult |
+          Select -ExpandProperty Results |% {
+            #write-warning $_.repository
+            #write-warning $_.repository.name
+            [pscustomobject]@{
+                Alerts = $alertCount
+                Value = $alertSecret
+                Path = $_.path
+                Project = $_.project | Select -ExpandProperty name
+                Repository = $_.repository | Select -ExpandProperty name
+                Matches = $_.matches.content.Count
+            }
+          } |
+          Group-Object Value |% {
+            [pscustomobject]@{
+                Alerts = $_.Group | Select -First 1 | Select -ExpandProperty Alerts
+                Value = $_.Group | Select -First 1 | Select -ExpandProperty Value
+                Found = $_.Group.Matches | Measure -Sum | Select -ExpandProperty Sum
+                Locations = $_.Group | Group-Object Project,Repository,Path | Select-Object -ExpandProperty Name
+            }
+          }
+      } |
+      Tee-Object -Variable CountedSecrets |
+      Sort-Object Found,Alerts -Descending

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metanull/appscan-client",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@metanull/appscan-client",
-      "version": "5.6.0",
+      "version": "5.6.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metanull/appscan-client",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Utility to work with HCL AppScan Cloud API",
   "main": "src/index.js",
   "type": "module",

--- a/src/cli/commands/list-azdo-secrets.js
+++ b/src/cli/commands/list-azdo-secrets.js
@@ -135,6 +135,13 @@ export async function listAzdoSecrets(options) {
           );
         };
 
+    // Streaming JSON callback - outputs NDJSON (one JSON per line) as alerts are found
+    const onAlert = options.json
+      ? (alert) => {
+          process.stdout.write(JSON.stringify(alert) + '\n');
+        }
+      : undefined;
+
     const alerts = await service.listAllSecretAlerts({
       projectId: options.appId,
       repositoryId: options.repositoryId,
@@ -142,6 +149,7 @@ export async function listAzdoSecrets(options) {
       includeDismissed: options.includeDismissed || false,
       includeFingerprint: true,
       onProgress,
+      onAlert,
     });
 
     // Clear progress line
@@ -149,8 +157,9 @@ export async function listAzdoSecrets(options) {
       process.stdout.write('\r' + ' '.repeat(80) + '\r');
     }
 
+    // In JSON mode, alerts were already streamed as NDJSON, nothing more to output
     if (options.json) {
-      cliOutput.json(alerts || []);
+      return;
     } else {
       cliOutput.result(
         chalk.green(`\nFound ${alerts?.length || 0} secret alert(s):\n`)

--- a/src/services/azdo-service.js
+++ b/src/services/azdo-service.js
@@ -523,6 +523,7 @@ export class AzdoService {
    * @param {boolean} [options.includeDismissed=false] - Include dismissed alerts
    * @param {boolean} [options.includeFingerprint=true] - Include fingerprint data for each alert
    * @param {Function} [options.onProgress] - Progress callback (processedRepos, totalRepos, alertsFound)
+   * @param {Function} [options.onAlert] - Callback invoked for each alert found, receives enriched alert object
    * @returns {Promise<Array>} Array of secret alerts with project/repo metadata
    */
   async listAllSecretAlerts(options = {}) {
@@ -535,6 +536,7 @@ export class AzdoService {
       includeDismissed = false,
       includeFingerprint = true,
       onProgress,
+      onAlert,
     } = options;
 
     const allAlerts = [];
@@ -626,13 +628,19 @@ export class AzdoService {
                 }
               }
 
-              allAlerts.push({
+              const enrichedAlert = {
                 ...alertData,
                 projectId: project.id,
                 projectName: project.name,
                 repositoryId: repo.id,
                 repositoryName: repo.name,
-              });
+              };
+
+              if (onAlert) {
+                onAlert(enrichedAlert);
+              }
+
+              allAlerts.push(enrichedAlert);
             }
           }
         } catch (error) {
@@ -649,6 +657,326 @@ export class AzdoService {
     }
 
     return allAlerts;
+  }
+
+  // ==========================================
+  // Pipeline Variables Methods
+  // ==========================================
+
+  /**
+   * Escapes special regex characters in a string to prevent regex injection
+   * @param {string} str - String to escape
+   * @returns {string} Escaped string safe for use in RegExp
+   */
+  static escapeRegex(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  /**
+   * List build definitions (pipelines) for a project
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {Object} [options] - Optional parameters
+   * @param {boolean} [options.includeAllProperties=true] - Include full definition with variables
+   * @returns {Promise<Array>} Array of build definitions
+   */
+  async listBuildDefinitions(projectIdOrName, options = {}) {
+    await this.connect();
+    const buildApi = await this.connection.getBuildApi();
+    const { includeAllProperties = true } = options;
+
+    const definitions = await buildApi.getDefinitions(
+      projectIdOrName,
+      undefined, // name
+      undefined, // repositoryId
+      undefined, // repositoryType
+      undefined, // queryOrder
+      undefined, // top
+      undefined, // continuationToken
+      undefined, // minMetricsTime
+      undefined, // definitionIds
+      undefined, // path
+      undefined, // builtAfter
+      undefined, // notBuiltAfter
+      includeAllProperties
+    );
+
+    return definitions || [];
+  }
+
+  /**
+   * Get a specific build definition with full details (including variables)
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {number} definitionId - Definition ID
+   * @returns {Promise<Object>} Build definition with variables
+   */
+  async getBuildDefinition(projectIdOrName, definitionId) {
+    await this.connect();
+    const buildApi = await this.connection.getBuildApi();
+    return await buildApi.getDefinition(projectIdOrName, definitionId);
+  }
+
+  /**
+   * List variable groups for a project
+   * @param {string} projectIdOrName - Project ID or name
+   * @returns {Promise<Array>} Array of variable groups
+   */
+  async listVariableGroups(projectIdOrName) {
+    await this.connect();
+    const taskAgentApi = await this.connection.getTaskAgentApi();
+    const groups = await taskAgentApi.getVariableGroups(projectIdOrName);
+    return groups || [];
+  }
+
+  /**
+   * Get a specific variable group
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {number} groupId - Variable group ID
+   * @returns {Promise<Object>} Variable group
+   */
+  async getVariableGroup(projectIdOrName, groupId) {
+    await this.connect();
+    const taskAgentApi = await this.connection.getTaskAgentApi();
+    return await taskAgentApi.getVariableGroup(projectIdOrName, groupId);
+  }
+
+  /**
+   * Search for pipeline variables across all pipelines in a project
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {Object} options - Search options
+   * @param {string} [options.searchValue] - Value to search for (only works for non-secret variables)
+   * @param {string} [options.searchName] - Variable name to search for (case-insensitive partial match, or regex if useRegex=true)
+   * @param {boolean} [options.includeSecrets=true] - Include secret variables in results (value will be null)
+   * @param {boolean} [options.useRegex=false] - Treat searchName and searchValue as regex patterns
+   * @returns {Promise<Array>} Array of matches { project, pipeline, variableName, variableValue, isSecret, source }
+   */
+  async searchPipelineVariables(projectIdOrName, options = {}) {
+    const {
+      searchValue,
+      searchName,
+      includeSecrets = true,
+      useRegex = false,
+    } = options;
+    const results = [];
+
+    // Compile regex patterns if useRegex is enabled
+    // When useRegex is false, escape special characters to prevent regex injection (CodeQL fix)
+    let nameRegex, valueRegex;
+    if (searchName) {
+      const pattern = useRegex
+        ? searchName
+        : AzdoService.escapeRegex(searchName);
+      nameRegex = new RegExp(pattern, 'i');
+    }
+    if (searchValue) {
+      const pattern = useRegex
+        ? searchValue
+        : AzdoService.escapeRegex(searchValue);
+      valueRegex = new RegExp(pattern, 'i');
+    }
+
+    // Get all build definitions
+    const definitions = await this.listBuildDefinitions(projectIdOrName, {
+      includeAllProperties: true,
+    });
+
+    for (const defRef of definitions) {
+      // Get full definition to access variables
+      let definition;
+      try {
+        definition = await this.getBuildDefinition(projectIdOrName, defRef.id);
+      } catch {
+        continue;
+      }
+
+      // Search in pipeline variables
+      if (definition.variables) {
+        for (const [varName, varData] of Object.entries(definition.variables)) {
+          const isSecret = varData.isSecret === true;
+          const value = varData.value;
+
+          // Skip secrets if not included
+          if (isSecret && !includeSecrets) continue;
+
+          // Check name match
+          let nameMatches;
+          if (!searchName) {
+            nameMatches = true;
+          } else {
+            nameMatches = nameRegex.test(varName);
+          }
+
+          // Check value match (only for non-secrets)
+          let valueMatches;
+          if (!searchValue) {
+            valueMatches = true;
+          } else if (isSecret) {
+            valueMatches = false;
+          } else {
+            valueMatches = value && valueRegex.test(value);
+          }
+
+          if (nameMatches && valueMatches) {
+            results.push({
+              projectName: projectIdOrName,
+              pipelineId: definition.id,
+              pipelineName: definition.name,
+              pipelinePath: definition.path || '\\',
+              variableName: varName,
+              variableValue: isSecret ? null : value,
+              isSecret,
+              source: 'pipeline',
+            });
+          }
+        }
+      }
+
+      // Search in linked variable groups
+      if (definition.variableGroups) {
+        for (const groupRef of definition.variableGroups) {
+          // Fetch full group details to get variable values
+          let group;
+          try {
+            group = await this.getVariableGroup(projectIdOrName, groupRef.id);
+          } catch {
+            continue;
+          }
+
+          if (!group.variables) continue;
+
+          for (const [varName, varData] of Object.entries(group.variables)) {
+            const isSecret = varData.isSecret === true;
+            const value = varData.value;
+
+            if (isSecret && !includeSecrets) continue;
+
+            // Check name match
+            let nameMatches;
+            if (!searchName) {
+              nameMatches = true;
+            } else {
+              nameMatches = nameRegex.test(varName);
+            }
+
+            // Check value match (only for non-secrets)
+            let valueMatches;
+            if (!searchValue) {
+              valueMatches = true;
+            } else if (isSecret) {
+              valueMatches = false;
+            } else {
+              valueMatches = value && valueRegex.test(value);
+            }
+
+            if (nameMatches && valueMatches) {
+              results.push({
+                projectName: projectIdOrName,
+                pipelineId: definition.id,
+                pipelineName: definition.name,
+                pipelinePath: definition.path || '\\',
+                variableGroupId: group.id,
+                variableGroupName: group.name,
+                variableName: varName,
+                variableValue: isSecret ? null : value,
+                isSecret,
+                source: 'variableGroup',
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Search for variables in variable groups across a project
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {Object} options - Search options
+   * @param {string} [options.searchValue] - Value to search for (only works for non-secret variables)
+   * @param {string} [options.searchName] - Variable name to search for (case-insensitive partial match, or regex if useRegex=true)
+   * @param {boolean} [options.includeSecrets=true] - Include secret variables in results
+   * @param {boolean} [options.useRegex=false] - Treat searchName and searchValue as regex patterns
+   * @returns {Promise<Array>} Array of matches
+   */
+  async searchVariableGroups(projectIdOrName, options = {}) {
+    const {
+      searchValue,
+      searchName,
+      includeSecrets = true,
+      useRegex = false,
+    } = options;
+    const results = [];
+
+    // Compile regex patterns if useRegex is enabled
+    // When useRegex is false, escape special characters to prevent regex injection (CodeQL fix)
+    let nameRegex, valueRegex;
+    if (searchName) {
+      const pattern = useRegex
+        ? searchName
+        : AzdoService.escapeRegex(searchName);
+      nameRegex = new RegExp(pattern, 'i');
+    }
+    if (searchValue) {
+      const pattern = useRegex
+        ? searchValue
+        : AzdoService.escapeRegex(searchValue);
+      valueRegex = new RegExp(pattern, 'i');
+    }
+
+    // Get list of variable groups (may not include full variable values)
+    const groupList = await this.listVariableGroups(projectIdOrName);
+
+    for (const groupRef of groupList) {
+      // Fetch full group details to get variable values
+      let group;
+      try {
+        group = await this.getVariableGroup(projectIdOrName, groupRef.id);
+      } catch {
+        continue;
+      }
+
+      if (!group.variables) continue;
+
+      for (const [varName, varData] of Object.entries(group.variables)) {
+        const isSecret = varData.isSecret === true;
+        const value = varData.value;
+
+        if (isSecret && !includeSecrets) continue;
+
+        // Check name match
+        let nameMatches;
+        if (!searchName) {
+          nameMatches = true;
+        } else {
+          nameMatches = nameRegex.test(varName);
+        }
+
+        // Check value match (only for non-secrets)
+        let valueMatches;
+        if (!searchValue) {
+          valueMatches = true;
+        } else if (isSecret) {
+          valueMatches = false;
+        } else {
+          valueMatches = value && valueRegex.test(value);
+        }
+
+        if (nameMatches && valueMatches) {
+          results.push({
+            projectName: projectIdOrName,
+            variableGroupId: group.id,
+            variableGroupName: group.name,
+            variableName: varName,
+            variableValue: isSecret ? null : value,
+            isSecret,
+            source: 'variableGroup',
+          });
+        }
+      }
+    }
+
+    return results;
   }
 }
 

--- a/src/tui/shared/services/azdo.js
+++ b/src/tui/shared/services/azdo.js
@@ -117,6 +117,69 @@ export class AzdoService {
     );
   }
 
+  // ==========================================
+  // Pipeline Variables Methods (delegated)
+  // ==========================================
+
+  /**
+   * List build definitions (pipelines) for a project
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {Object} [options] - Optional parameters
+   * @returns {Promise<Array>} Array of build definitions
+   */
+  async listBuildDefinitions(projectIdOrName, options = {}) {
+    return this.service.listBuildDefinitions(projectIdOrName, options);
+  }
+
+  /**
+   * Get a specific build definition with full details (including variables)
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {number} definitionId - Definition ID
+   * @returns {Promise<Object>} Build definition with variables
+   */
+  async getBuildDefinition(projectIdOrName, definitionId) {
+    return this.service.getBuildDefinition(projectIdOrName, definitionId);
+  }
+
+  /**
+   * List variable groups for a project
+   * @param {string} projectIdOrName - Project ID or name
+   * @returns {Promise<Array>} Array of variable groups
+   */
+  async listVariableGroups(projectIdOrName) {
+    return this.service.listVariableGroups(projectIdOrName);
+  }
+
+  /**
+   * Get a specific variable group
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {number} groupId - Variable group ID
+   * @returns {Promise<Object>} Variable group
+   */
+  async getVariableGroup(projectIdOrName, groupId) {
+    return this.service.getVariableGroup(projectIdOrName, groupId);
+  }
+
+  /**
+   * Search for pipeline variables across all pipelines in a project
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {Object} options - Search options
+   * @returns {Promise<Array>} Array of matches
+   */
+  async searchPipelineVariables(projectIdOrName, options = {}) {
+    return this.service.searchPipelineVariables(projectIdOrName, options);
+  }
+
+  /**
+   * Search for variables in variable groups across a project
+   * @param {string} projectIdOrName - Project ID or name
+   * @param {Object} options - Search options
+   * @returns {Promise<Array>} Array of matches
+   */
+  async searchVariableGroups(projectIdOrName, options = {}) {
+    return this.service.searchVariableGroups(projectIdOrName, options);
+  }
+
   /**
    * Build the web URL to view an alert in Azure DevOps browser
    * @param {string} projectName - Project name


### PR DESCRIPTION
## Summary
This PR combines the changes from PR #95 and #98, rebased onto main with CodeQL issues fixed.

### Features from PR #95 (feat/azdo-vars):
- **Pipeline variable search functionality** in AzdoService:
  - `listBuildDefinitions()` - List all pipelines for a project
  - `getBuildDefinition()` - Get pipeline details with variables
  - `listVariableGroups()` - List all variable groups
  - `getVariableGroup()` - Get variable group details
  - `searchPipelineVariables()` - Search across pipeline variables
  - `searchVariableGroups()` - Search across variable groups
- Added `escapeRegex()` static helper to **prevent regex injection** (CodeQL fix)
- New lab script: `azdo-16-search-pipeline-variables.js`

### Features from PR #98 (fix/list-secret-json-buffering):
- Added `onAlert` callback to `listAllSecretAlerts()` for **streaming NDJSON output**
- Updated `list-azdo-secrets` CLI to stream JSON as alerts are found (no buffering)
- New lab script: `secrets-list-and-search-code.ps1`

### CodeQL Fix
The original PR #95 had regex injection vulnerabilities where user input was passed directly to `new RegExp()`. This is now fixed by:
1. Adding a static `escapeRegex()` method that escapes all special regex characters
2. When `useRegex=false` (the default), user input is escaped before constructing the RegExp
3. When `useRegex=true`, the user explicitly opts into regex mode (advanced use case)

### Supersedes
- PR #95 (can be closed)
- PR #98 (can be closed)
- PR #99 (duplicate of #98, can be closed)

### Testing
- All tests pass ✅
- Lint passes ✅
- Build succeeds ✅